### PR TITLE
Improved JSON serialisation for Bitcoin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ near-sdk = { version = "5.3.0" }
 serde-big-array = "0.5.1"
 bs58 = "0.5.1"
 serde = "1.0"
+serde_json = "1.0"
 sha2 = { version = "0.10.8", optional = true }
 
 [dev-dependencies]
@@ -68,4 +69,3 @@ tokio = { version = "1.38", features = ["full"] }
 
 # misc
 eyre = "0.6"
-serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ overflow-checks = true
 [features]
 default = ["all"]
 all = ["near", "bitcoin", "evm"]
-bitcoin = ["sha2"]
+bitcoin = ["sha2", "schemars"]
 evm = []
 near = []
 
@@ -34,6 +34,7 @@ bs58 = "0.5.1"
 serde = "1.0"
 serde_json = "1.0"
 sha2 = { version = "0.10.8", optional = true }
+schemars = { version = "0.8.11", optional = true }
 
 [dev-dependencies]
 # ethereum

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -1,5 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
 use sha2::{Digest, Sha256};
 use std::io::{BufRead, Write};
 
@@ -11,7 +12,17 @@ use super::{
     },
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
+)]
 #[serde(crate = "near_sdk::serde")]
 pub struct BitcoinTransaction {
     /// The protocol version, is currently expected to be 1 or 2 (BIP 68).

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -12,6 +12,7 @@ use super::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(crate = "near_sdk::serde")]
 pub struct BitcoinTransaction {
     /// The protocol version, is currently expected to be 1 or 2 (BIP 68).
     pub version: Version,

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -675,4 +675,75 @@ mod tests {
         assert_eq!(tx.output[1].value, OmniAmount::from_sat(2649));
         assert_eq!(tx.output.len(), 2);
     }
+
+    #[test]
+    fn test_from_json_bitcoin_transaction_4() {
+        let json = r#"
+            {
+                "version": "2",
+                "lock_time": "0",
+                "input": [
+                    {
+                        "previous_output": {
+                            "txid": "bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a",
+                            "vout": 0
+                        },
+                        "script_sig": [],
+                        "sequence": 4294967295,
+                        "witness": []
+                    }
+                ],
+                "output": [
+                    {
+                        "value": 1,
+                        "script_pubkey": "76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ad"
+                    },
+                    {
+                        "value": 2649,
+                        "script_pubkey": "76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ac"
+                    }
+                ]
+            }
+        "#;
+
+        let tx = OmniBitcoinTransaction::from_json(json).unwrap();
+        println!("tx: {:?}", tx);
+
+        assert_eq!(tx.version, Version::Two);
+        assert_eq!(tx.lock_time, LockTime::from_height(0).unwrap());
+    }
+
+    #[test]
+    fn test_from_json_bitcoin_transaction_5() {
+        let json_data = r#"
+        {
+            "version": 1,
+            "lock_time": 1,
+            "input": [
+                {
+                    "previous_output": {
+                        "txid": [59, 103, 22, 67, 189, 12, 138, 114, 42, 90, 207, 173, 211, 254, 197, 194, 92, 65, 224, 168, 146, 169, 213, 217, 184, 81, 123, 217, 19, 81, 69, 71],
+                        "vout": 0
+                    },
+                    "script_sig": [],
+                    "sequence": 4294967295,
+                    "witness": []
+                }
+            ],
+            "output": [
+                {
+                    "value": 500000000,
+                    "script_pubkey": [118, 169, 20, 136, 240, 168, 35, 147, 140, 88, 207, 91, 23, 200, 235, 147, 198, 130, 128, 99, 91, 115, 78, 136, 172]
+                },
+                {
+                    "value": 4499999000,
+                    "script_pubkey": [118, 169, 20, 197, 64, 140, 145, 44, 231, 221, 181, 123, 174, 124, 22, 79, 148, 247, 47, 225, 189, 178, 180, 136, 172]
+                }
+            ]
+        }
+        "#;
+
+        let result: Result<BitcoinTransaction, _> = serde_json::from_str(json_data);
+        assert!(result.is_ok(), "Failed to deserialize: {:?}", result.err());
+    }
 }

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -564,5 +564,103 @@ mod tests {
 
         let tx = OmniBitcoinTransaction::from_json(json).unwrap();
         println!("tx: {:?}", tx);
+
+        assert_eq!(tx.version, Version::One);
+        assert_eq!(tx.lock_time, LockTime::from_height(0).unwrap());
+        // input
+        assert_eq!(tx.input[0].script_sig, OmniScriptBuf::default());
+        assert_eq!(tx.input[0].witness, OmniWitness::default());
+        assert_eq!(tx.input[0].sequence, OmniSequence(4294967295));
+        assert_eq!(
+            tx.input[0].previous_output,
+            OmniOutPoint {
+                txid: OmniTxid(
+                    OmniHash::from_hex(
+                        "bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a"
+                    )
+                    .unwrap()
+                ),
+                vout: 0
+            }
+        );
+        assert_eq!(tx.input.len(), 1);
+        // output
+        assert_eq!(
+            tx.output[0].script_pubkey,
+            OmniScriptBuf::from_hex("76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ad").unwrap()
+        );
+        assert_eq!(
+            tx.output[1].script_pubkey,
+            OmniScriptBuf::from_hex("76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ac").unwrap()
+        );
+        assert_eq!(tx.output[0].value, OmniAmount::from_sat(1));
+        assert_eq!(tx.output[1].value, OmniAmount::from_sat(2649));
+        assert_eq!(tx.output.len(), 2);
+    }
+
+    #[test]
+    fn test_from_json_bitcoin_transaction_3() {
+        let json = r#"
+        {
+            "version": "2",
+            "lock_time": "0",
+            "input": [
+                {
+                    "previous_output": {
+                        "txid": "bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a",
+                        "vout": 0
+                    },
+                    "script_sig": [],
+                    "sequence": 4294967295,
+                    "witness": []
+                }
+            ],
+            "output": [
+                {
+                    "value": 1,
+                    "script_pubkey": "76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ad"
+                },
+                {
+                    "value": 2649,
+                    "script_pubkey": "76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ac"
+                }
+            ]
+        }
+        "#;
+
+        let tx = OmniBitcoinTransaction::from_json(json).unwrap();
+        println!("tx: {:?}", tx);
+
+        assert_eq!(tx.version, Version::Two);
+        assert_eq!(tx.lock_time, LockTime::from_height(0).unwrap());
+        // input
+        assert_eq!(tx.input[0].script_sig, OmniScriptBuf::default());
+        assert_eq!(tx.input[0].witness, OmniWitness::default());
+        assert_eq!(tx.input[0].sequence, OmniSequence(4294967295));
+        assert_eq!(
+            tx.input[0].previous_output,
+            OmniOutPoint {
+                txid: OmniTxid(
+                    OmniHash::from_hex(
+                        "bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a"
+                    )
+                    .unwrap()
+                ),
+                vout: 0
+            }
+        );
+        assert_eq!(tx.input.len(), 1);
+        // output
+        assert_eq!(
+            tx.output[0].script_pubkey,
+            OmniScriptBuf::from_hex("76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ad").unwrap()
+        );
+        assert_eq!(
+            tx.output[1].script_pubkey,
+            OmniScriptBuf::from_hex("76a9148356ecd5f1761e60c144dc2f4de6bf7d8be7690688ac").unwrap()
+        );
+        assert_eq!(tx.output[0].value, OmniAmount::from_sat(1));
+        assert_eq!(tx.output[1].value, OmniAmount::from_sat(2649));
+        assert_eq!(tx.output.len(), 2);
     }
 }

--- a/src/bitcoin/types/lock_time/lock_time.rs
+++ b/src/bitcoin/types/lock_time/lock_time.rs
@@ -1,10 +1,17 @@
-use crate::bitcoin::encoding::{Decodable, Encodable};
+use crate::bitcoin::{
+    encoding::{Decodable, Encodable},
+    types::lock_time::constants::LOCK_TIME_THRESHOLD,
+};
 
 use super::{height::Height, time::Time};
-use std::io::{BufRead, Write};
+use std::{
+    fmt,
+    io::{BufRead, Write},
+};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
+use serde::Deserializer;
 
 /// Locktime itself is an unsigned 4-byte integer which can be parsed two ways:
 ///
@@ -16,9 +23,7 @@ use near_sdk::serde::{Deserialize, Serialize};
 /// The transaction can be added to any block whose block time is greater than the locktime.
 ///
 /// [Bitcoin Devguide]: https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, BorshSerialize, BorshDeserialize)]
 pub struct LockTime(u32);
 
 impl LockTime {
@@ -66,6 +71,64 @@ impl Decodable for LockTime {
         let mut buf: [u8; 4] = [0; 4];
         r.read_exact(&mut buf)?;
         Ok(Self(u32::from_le_bytes(buf)))
+    }
+}
+
+impl<'de> Deserialize<'de> for LockTime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringOrNumberVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for StringOrNumberVisitor {
+            type Value = LockTime;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string or a number")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<LockTime, E>
+            where
+                E: serde::de::Error,
+            {
+                if let Ok(value_parsed) = value.parse::<u32>() {
+                    if value_parsed < LOCK_TIME_THRESHOLD {
+                        return Ok(LockTime::from_height(value_parsed).unwrap());
+                    } else {
+                        return Ok(LockTime::from_time(value_parsed).unwrap());
+                    }
+                }
+                // if the string is not a valid number, we return an error
+                Err(serde::de::Error::custom(
+                    "Invalid lock time: expected a number",
+                ))
+            }
+
+            fn visit_u32<E>(self, value: u32) -> Result<LockTime, E>
+            where
+                E: serde::de::Error,
+            {
+                if value < LOCK_TIME_THRESHOLD {
+                    Ok(LockTime::from_height(value).unwrap())
+                } else {
+                    Ok(LockTime::from_time(value).unwrap())
+                }
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<LockTime, E>
+            where
+                E: serde::de::Error,
+            {
+                if value < LOCK_TIME_THRESHOLD as u64 {
+                    Ok(LockTime::from_height(value as u32).unwrap())
+                } else {
+                    Ok(LockTime::from_time(value as u32).unwrap())
+                }
+            }
+        }
+
+        deserializer.deserialize_any(StringOrNumberVisitor)
     }
 }
 
@@ -153,5 +216,21 @@ mod tests {
 
         let decoded = LockTime::decode(&mut &buffer[..]).unwrap();
         assert_eq!(locktime, decoded);
+    }
+
+    #[test]
+    fn test_from_json_locktime() {
+        let json = r#"0"#;
+
+        let locktime: LockTime = serde_json::from_str(json).unwrap();
+        assert_eq!(locktime, LockTime::from_height(0).unwrap());
+    }
+
+    #[test]
+    fn test_serde_json_locktime_with_number_as_string() {
+        let json = r#""0""#;
+
+        let locktime: LockTime = serde_json::from_str(json).unwrap();
+        assert_eq!(locktime, LockTime::from_height(0).unwrap());
     }
 }

--- a/src/bitcoin/types/lock_time/lock_time.rs
+++ b/src/bitcoin/types/lock_time/lock_time.rs
@@ -11,6 +11,7 @@ use std::{
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
 use serde::Deserializer;
 
 /// Locktime itself is an unsigned 4-byte integer which can be parsed two ways:
@@ -23,7 +24,9 @@ use serde::Deserializer;
 /// The transaction can be added to any block whose block time is greater than the locktime.
 ///
 /// [Bitcoin Devguide]: https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, BorshSerialize, BorshDeserialize, JsonSchema,
+)]
 pub struct LockTime(u32);
 
 impl LockTime {

--- a/src/bitcoin/types/script_buf.rs
+++ b/src/bitcoin/types/script_buf.rs
@@ -2,10 +2,11 @@ use core::fmt;
 use std::io::{BufRead, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 
 use crate::bitcoin::encoding::{encode::Encodable, Decodable};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, JsonSchema)]
 pub struct ScriptBuf(pub Vec<u8>);
 
 impl ScriptBuf {

--- a/src/bitcoin/types/script_buf.rs
+++ b/src/bitcoin/types/script_buf.rs
@@ -2,13 +2,10 @@ use core::fmt;
 use std::io::{BufRead, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::encoding::{encode::Encodable, Decodable};
 
-#[derive(
-    Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
-)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ScriptBuf(pub Vec<u8>);
 
 impl ScriptBuf {
@@ -51,5 +48,92 @@ impl Encodable for ScriptBuf {
 impl Decodable for ScriptBuf {
     fn decode_from_finite_reader<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, std::io::Error> {
         Ok(Self(Decodable::decode_from_finite_reader(r)?))
+    }
+}
+
+impl serde::Serialize for ScriptBuf {
+    /// User-facing serialization for `Script`.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ScriptBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt::Formatter;
+
+        if deserializer.is_human_readable() {
+            struct Visitor;
+            impl<'de> serde::de::Visitor<'de> for Visitor {
+                type Value = ScriptBuf;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    println!("expecting");
+                    formatter.write_str("a script hex")
+                }
+
+                // fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                // where
+                //     E: serde::de::Error,
+                // {
+                //     Ok(ScriptBuf::from_hex(v).unwrap())
+                // }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    if v.is_empty() {
+                        Ok(ScriptBuf(vec![]))
+                    } else {
+                        ScriptBuf::from_hex(v).map_err(E::custom)
+                    }
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+                where
+                    A: serde::de::SeqAccess<'de>,
+                {
+                    let mut vec = Vec::new();
+                    while let Some(byte) = seq.next_element()? {
+                        vec.push(byte);
+                    }
+                    Ok(ScriptBuf(vec))
+                }
+            }
+            // deserializer.deserialize_str(Visitor)
+            deserializer.deserialize_any(Visitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> serde::de::Visitor<'de> for BytesVisitor {
+                type Value = ScriptBuf;
+
+                fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                    formatter.write_str("a script Vec<u8>")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(ScriptBuf::from_bytes(v.to_vec()))
+                }
+
+                fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(ScriptBuf::from_bytes(v))
+                }
+            }
+            deserializer.deserialize_byte_buf(BytesVisitor)
+        }
     }
 }

--- a/src/bitcoin/types/tx_in/hash.rs
+++ b/src/bitcoin/types/tx_in/hash.rs
@@ -2,13 +2,24 @@ use core::fmt;
 use std::{io::BufRead, str::FromStr};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::encoding::{encode::Encodable, extensions::WriteExt, Decodable};
 
 #[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
 )]
+#[serde(crate = "near_sdk::serde")]
 pub struct Hash(pub [u8; 32]);
 
 impl Hash {

--- a/src/bitcoin/types/tx_in/hash.rs
+++ b/src/bitcoin/types/tx_in/hash.rs
@@ -9,7 +9,7 @@ use crate::bitcoin::encoding::{encode::Encodable, extensions::WriteExt, Decodabl
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]
-pub struct Hash([u8; 32]);
+pub struct Hash(pub [u8; 32]);
 
 impl Hash {
     pub const fn as_byte_array(&self) -> [u8; 32] {

--- a/src/bitcoin/types/tx_in/outpoint.rs
+++ b/src/bitcoin/types/tx_in/outpoint.rs
@@ -1,20 +1,22 @@
-use std::io::{BufRead, Write};
+use std::{
+    fmt,
+    io::{BufRead, Write},
+};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
+use serde::{de::MapAccess, Deserialize, Deserializer, Serialize};
+
+use super::hash::Hash;
+use super::tx_id::Txid;
 
 use crate::bitcoin::encoding::{Decodable, Encodable};
-
-use super::tx_id::Txid;
 
 /// A reference to a transaction output.
 ///
 /// ### Bitcoin Core References
 ///
 /// * [COutPoint definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L26)
-#[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
-)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 pub struct OutPoint {
     /// The referenced transaction's txid.
     pub txid: Txid,
@@ -69,6 +71,72 @@ impl Decodable for OutPoint {
     }
 }
 
+impl<'de> Deserialize<'de> for OutPoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(OutPointVisitor)
+    }
+}
+
+struct OutPointVisitor;
+
+impl<'de> serde::de::Visitor<'de> for OutPointVisitor {
+    type Value = OutPoint;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a map with txid as a hex string and vout as a number or string")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<OutPoint, V::Error>
+    where
+        V: MapAccess<'de>,
+    {
+        let mut txid = None;
+        let mut vout = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "txid" => {
+                    let txid_str: String = map.next_value()?;
+                    let txid_bytes = hex::decode(&txid_str).map_err(serde::de::Error::custom)?;
+                    if txid_bytes.len() != 32 {
+                        return Err(serde::de::Error::custom("Invalid txid length"));
+                    }
+                    let mut hash_bytes = [0u8; 32];
+                    hash_bytes.copy_from_slice(&txid_bytes);
+                    txid = Some(Txid(Hash(hash_bytes)));
+                }
+                "vout" => {
+                    println!("vout");
+                    vout = Some(
+                        map.next_value::<serde_json::Value>()
+                            .and_then(|vout_value| match vout_value {
+                                serde_json::Value::Number(num) => num
+                                    .as_u64()
+                                    .map(|n| n as u32)
+                                    .ok_or_else(|| serde::de::Error::custom("Invalid vout number")),
+                                serde_json::Value::String(s) => s
+                                    .parse::<u32>()
+                                    .map_err(|_| serde::de::Error::custom("Invalid vout string")),
+                                _ => Err(serde::de::Error::custom("Invalid vout type")),
+                            })?,
+                    );
+                }
+                _ => {
+                    return Err(serde::de::Error::custom(format!("Unexpected key: {}", key)));
+                }
+            }
+        }
+
+        let txid = txid.ok_or_else(|| serde::de::Error::missing_field("txid"))?;
+        let vout = vout.ok_or_else(|| serde::de::Error::missing_field("vout"))?;
+
+        Ok(OutPoint { txid, vout })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,5 +154,51 @@ mod tests {
 
         let decoded_outpoint = OutPoint::decode_from_finite_reader(&mut buf.as_slice()).unwrap();
         assert_eq!(decoded_outpoint, outpoint);
+    }
+
+    #[test]
+    fn test_serde_json_outpoint() {
+        let json_string = r#"{
+            "txid":"bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a",
+            "vout":0
+        }"#;
+
+        let outpoint: OutPoint = serde_json::from_str(json_string).unwrap();
+        println!("outpoint = {:?}", outpoint);
+        assert_eq!(
+            outpoint,
+            OutPoint {
+                txid: Txid(
+                    Hash::from_hex(
+                        "bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a"
+                    )
+                    .unwrap()
+                ),
+                vout: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_serde_json_outpoint_with_string_vout() {
+        let json_string = r#"{
+            "txid":"bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a",
+            "vout":"0"
+        }"#;
+
+        let outpoint: OutPoint = serde_json::from_str(json_string).unwrap();
+        println!("outpoint = {:?}", outpoint);
+        assert_eq!(
+            outpoint,
+            OutPoint {
+                txid: Txid(
+                    Hash::from_hex(
+                        "bc25cc0dddd0a202c21e66521a692c0586330a9a9dcc38ccd9b4d2093037f31a"
+                    )
+                    .unwrap()
+                ),
+                vout: 0
+            }
+        );
     }
 }

--- a/src/bitcoin/types/tx_in/outpoint.rs
+++ b/src/bitcoin/types/tx_in/outpoint.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{de::MapAccess, Deserialize, Deserializer, Serialize};
 
 use super::hash::Hash;
@@ -16,7 +17,10 @@ use crate::bitcoin::encoding::{Decodable, Encodable};
 /// ### Bitcoin Core References
 ///
 /// * [COutPoint definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L26)
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize, JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
 pub struct OutPoint {
     /// The referenced transaction's txid.
     pub txid: Txid,

--- a/src/bitcoin/types/tx_in/sequence.rs
+++ b/src/bitcoin/types/tx_in/sequence.rs
@@ -1,14 +1,25 @@
 use std::io::{BufRead, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::encoding::{Decodable, Encodable};
 
 /// Bitcoin transaction input sequence number.
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
 )]
+#[serde(crate = "near_sdk::serde")]
 pub struct Sequence(pub u32);
 
 impl Sequence {

--- a/src/bitcoin/types/tx_in/tx_id.rs
+++ b/src/bitcoin/types/tx_in/tx_id.rs
@@ -5,11 +5,22 @@ use crate::bitcoin::encoding::{Decodable, Encodable};
 
 use super::hash::Hash;
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
+    Debug,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
 )]
+#[serde(crate = "near_sdk::serde")]
 pub struct Txid(pub Hash);
 
 impl Txid {

--- a/src/bitcoin/types/tx_in/tx_in.rs
+++ b/src/bitcoin/types/tx_in/tx_in.rs
@@ -1,10 +1,10 @@
 use std::io::{self, BufRead, Write};
 
-use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
-
 use crate::bitcoin::encoding::{Decodable, Encodable};
 use crate::bitcoin::types::script_buf::ScriptBuf;
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
 
 use super::{outpoint::OutPoint, sequence::Sequence, witness::Witness};
 
@@ -17,7 +17,18 @@ use super::{outpoint::OutPoint, sequence::Sequence, witness::Witness};
 /// ### Bitcoin Core References
 ///
 /// * [CTxIn definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L65)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
 pub struct TxIn {
     /// The reference to the previous output that is being used as an input.
     pub previous_output: OutPoint,

--- a/src/bitcoin/types/tx_in/witness.rs
+++ b/src/bitcoin/types/tx_in/witness.rs
@@ -1,6 +1,8 @@
 use std::io::{BufRead, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Deserializer, Serialize, Serializer};
+use schemars::JsonSchema;
 
 use crate::bitcoin::encoding::{
     decode::MAX_VEC_SIZE, extensions::WriteExt, utils::VarInt, Decodable, Encodable,
@@ -16,7 +18,7 @@ use crate::bitcoin::encoding::{
 /// saving some allocations.
 ///
 /// [segwit upgrade]: <https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki>
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, JsonSchema)]
 pub struct Witness {
     /// Contains the witness `Vec<Vec<u8>>` serialization.
     ///
@@ -261,10 +263,10 @@ fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
 
 pub struct SerializeBytesAsHex<'a>(pub(crate) &'a [u8]);
 
-impl<'a> serde::Serialize for SerializeBytesAsHex<'a> {
+impl<'a> Serialize for SerializeBytesAsHex<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         use hex::ToHex;
 
@@ -273,10 +275,10 @@ impl<'a> serde::Serialize for SerializeBytesAsHex<'a> {
 }
 
 // Serde keep backward compatibility with old Vec<Vec<u8>> format
-impl serde::Serialize for Witness {
+impl Serialize for Witness {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         use serde::ser::SerializeSeq;
 
@@ -295,10 +297,10 @@ impl serde::Serialize for Witness {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Witness {
+impl<'de> Deserialize<'de> for Witness {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct Visitor; // Human-readable visitor.
 

--- a/src/bitcoin/types/tx_in/witness.rs
+++ b/src/bitcoin/types/tx_in/witness.rs
@@ -1,7 +1,6 @@
 use std::io::{BufRead, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::encoding::{
     decode::MAX_VEC_SIZE, extensions::WriteExt, utils::VarInt, Decodable, Encodable,
@@ -17,7 +16,7 @@ use crate::bitcoin::encoding::{
 /// saving some allocations.
 ///
 /// [segwit upgrade]: <https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki>
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Witness {
     /// Contains the witness `Vec<Vec<u8>>` serialization.
     ///
@@ -257,5 +256,101 @@ fn resize_if_needed(vec: &mut Vec<u8>, required_len: usize) {
             new_len *= 2;
         }
         vec.resize(new_len, 0);
+    }
+}
+
+pub(crate) struct SerializeBytesAsHex<'a>(pub(crate) &'a [u8]);
+
+impl<'a> serde::Serialize for SerializeBytesAsHex<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use hex::ToHex;
+
+        serializer.collect_str(&format_args!("{}", self.0.encode_hex::<String>()))
+    }
+}
+
+// Serde keep backward compatibility with old Vec<Vec<u8>> format
+impl serde::Serialize for Witness {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let human_readable = serializer.is_human_readable();
+        let mut seq = serializer.serialize_seq(Some(self.witness_elements))?;
+
+        // Note that the `Iter` strips the varints out when iterating.
+        for elem in self.iter() {
+            if human_readable {
+                seq.serialize_element(&SerializeBytesAsHex(elem))?;
+            } else {
+                seq.serialize_element(&elem)?;
+            }
+        }
+        seq.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Witness {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor; // Human-readable visitor.
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Witness;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "a sequence of hex arrays")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut a: A,
+            ) -> Result<Self::Value, A::Error> {
+                use serde::de::{self, Unexpected};
+                let mut ret = match a.size_hint() {
+                    Some(len) => Vec::with_capacity(len),
+                    None => Vec::new(),
+                };
+
+                while let Some(elem) = a.next_element::<String>()? {
+                    let vec = hex::decode(&elem).map_err(|e| match e {
+                        hex::FromHexError::InvalidHexCharacter { c, .. } => {
+                            match core::char::from_u32(c.into()) {
+                                Some(c) => de::Error::invalid_value(
+                                    Unexpected::Char(c),
+                                    &"a valid hex character",
+                                ),
+                                None => de::Error::invalid_value(
+                                    Unexpected::Other("invalid hex character"),
+                                    &"a valid hex character",
+                                ),
+                            }
+                        }
+                        hex::FromHexError::OddLength => {
+                            de::Error::invalid_length(0, &"an even length string")
+                        }
+                        hex::FromHexError::InvalidStringLength => {
+                            de::Error::invalid_length(0, &"an even length string")
+                        }
+                    })?;
+                    ret.push(vec);
+                }
+                Ok(Witness::from_slice(&ret))
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_seq(Visitor)
+        } else {
+            let vec: Vec<Vec<u8>> = serde::Deserialize::deserialize(deserializer)?;
+            Ok(Witness::from_slice(&vec))
+        }
     }
 }

--- a/src/bitcoin/types/tx_out/amount.rs
+++ b/src/bitcoin/types/tx_out/amount.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::encoding::{Decodable, Encodable};
@@ -13,8 +14,18 @@ use crate::bitcoin::encoding::{Decodable, Encodable};
 /// The [`Amount`] type can be used to express Bitcoin amounts that support
 /// arithmetic and conversion to various denominations.
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
 )]
+#[serde(crate = "near_sdk::serde")]
 pub struct Amount(u64);
 
 impl Amount {

--- a/src/bitcoin/types/tx_out/tx_out.rs
+++ b/src/bitcoin/types/tx_out/tx_out.rs
@@ -1,6 +1,7 @@
 use std::io::{BufRead, Write};
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::bitcoin::{
@@ -21,7 +22,18 @@ use super::amount::Amount;
 /// ### Bitcoin Core References
 ///
 /// * [CTxOut definition](https://github.com/bitcoin/bitcoin/blob/345457b542b6a980ccfbc868af0970a6f91d1b82/src/primitives/transaction.h#L148)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
 pub struct TxOut {
     /// The value of the output, in satoshis.
     pub value: Amount,

--- a/src/bitcoin/types/version.rs
+++ b/src/bitcoin/types/version.rs
@@ -5,6 +5,7 @@ use std::{
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
+use schemars::JsonSchema;
 use serde::Deserializer;
 
 use crate::bitcoin::encoding::{Decodable, Encodable};
@@ -14,7 +15,7 @@ use crate::bitcoin::encoding::{Decodable, Encodable};
 /// Currently, as specified by [BIP-68], only version 1 and 2 are considered standard.
 ///
 /// [BIP-68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
-#[derive(Debug, Copy, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Copy, PartialEq, Eq, Clone, BorshSerialize, BorshDeserialize, JsonSchema)]
 #[borsh(use_discriminant = true)]
 pub enum Version {
     /// The original Bitcoin transaction version (pre-BIP-68)

--- a/src/bitcoin/types/version.rs
+++ b/src/bitcoin/types/version.rs
@@ -67,8 +67,8 @@ impl Serialize for Version {
         S: serde::Serializer,
     {
         let version_number = match self {
-            Version::One => 1,
-            Version::Two => 2,
+            Self::One => 1,
+            Self::Two => 2,
         };
         serializer.serialize_i32(version_number)
     }
@@ -133,7 +133,11 @@ impl<'de> Deserialize<'de> for Version {
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.to_string(), f)
+        let version_number = match self {
+            Self::One => "1",
+            Self::Two => "2",
+        };
+        write!(f, "{}", version_number)
     }
 }
 

--- a/tests/bitcoin_integration_test.rs
+++ b/tests/bitcoin_integration_test.rs
@@ -62,8 +62,6 @@ async fn test_send_p2pkh_using_rust_bitcoin_and_omni_library() -> Result<()> {
     let blockchain_info = client.get_blockchain_info().unwrap();
     assert_eq!(0, blockchain_info.blocks);
 
-    // let bitcoind = bitcoind::BitcoinD::new().unwrap();
-
     // Setup testing environment
     let mut btc_test_context = BTCTestContext::new(client).unwrap();
 


### PR DESCRIPTION
This PR fixed the JSON serialisation problems with BTC.

- Added schemars
- serde serialisation for:
    - OutPoint
    - Witness
    - Version
    - ScriptBuf
    - Locktime 